### PR TITLE
Lower emacs version req to work on Debian stable

### DIFF
--- a/elpher.el
+++ b/elpher.el
@@ -7,7 +7,7 @@
 ;; Version: 2.10.2
 ;; Keywords: comm gopher
 ;; Homepage: http://thelambdalab.xyz/elpher
-;; Package-Requires: ((emacs "26.2"))
+;; Package-Requires: ((emacs "26.1"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
26.1 is the version of emacs available in Debian 10 (stable) and elpher cannot be installed via package-install with a requires directive of 26.2. The change to 26.2 was only recently updated and reverting does not appear to have any negative consequences.

Thanks for your interest in contributing to this package.

This repository is only a mirror.  Please do not open a pull-request here.  Instead figure out where the upstream repository is and open a pull-request there.  If the upstream repository is located on Github, then you should see a link "forked from somebody-else/this-project" should be visible above and that link should take you there.
